### PR TITLE
Adding self-ancestry detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ See [Samvera::NestingIndexer::Documents::IndexDocument](./lib/samvera/nesting_in
 
 To reindex a single document, we leverage the [`Samvera::NestingIndexer.reindex_relationships`](./lib/samvera/nesting_indexer.rb) method.
 
+To reindex all of the documents, we leverage the [`Samvera::NestingIndexer.reindex_all!`](lib/samvera/nesting_indexer.rb) method. **Warning: This is a very slow process.**
+
 ## Examples
 
 Given the following PreservationDocuments:
@@ -112,3 +114,10 @@ When dealing with nested graphs, there is a danger of creating an cycle (e.g. `A
 The [`./spec/features/reindex_pid_and_descendants_spec.rb`](spec/features/reindex_pid_and_descendants_spec.rb) contains examples of behavior.
 
 **NOTE: These guards to prevent indexing cyclic graphs do not prevent the underlying preservation document from creating its own cyclic graph.**
+
+## TODO
+
+- [ ] Incorporate additional logging
+- [ ] Build methods to allow for fanning out the reindexing. At present, when we reindex a node and its "children", we run that entire process within a single context. Likewise, we run a single process when reindexing EVERYTHING.
+- [ ] Promote from [samvera-labs](https://github.com/samvera-labs) to [samvera](https://github.com/samvera) via the [promotion process](http://samvera-labs.github.io/promotion.html).
+- [ ] Write adapter method to assist in guarding against self-ancestry. We could probably expose a base adapter that has the method through use of the other adapter methods.

--- a/README.md
+++ b/README.md
@@ -101,3 +101,14 @@ Given a single object A, when we reindex A, we:
 * Iterate through each descendant, in a breadth-first process, to reindex it (and each descendant's descendants).
 
 This is a potentially time consumptive process and should not be run within the request cycle.
+
+### Cycle Detections
+
+When dealing with nested graphs, there is a danger of creating an cycle (e.g. `A ={ B ={ A`). Samvera::NestingIndexer implements two guards to short-circuit the indexing of cyclic graphs:
+
+* Enforcing a maximum nesting depth of the graph
+* Checking that an object is not its own ancestor (`Samvera::NestingIndexer::RelationshipReindexer#guard_against_possiblity_of_self_ancestry`)
+
+The [`./spec/features/reindex_pid_and_descendants_spec.rb`](spec/features/reindex_pid_and_descendants_spec.rb) contains examples of behavior.
+
+**NOTE: These guards to prevent indexing cyclic graphs do not prevent the underlying preservation document from creating its own cyclic graph.**

--- a/README.md
+++ b/README.md
@@ -87,10 +87,7 @@ RSpec.describe MyCustomAdapter
 end
 ```
 
-
-
-
-[See CurateND for our adaptor configuration](https://github.com/ndlib/samvera_nd/blob/6fbe79c9725c0f8b4641981044ec250c5163053b/config/initializers/samvera_config.rb#L32-L35).
+[See CurateND for Notre Dame's adaptor configuration](https://github.com/ndlib/samvera_nd/blob/6fbe79c9725c0f8b4641981044ec250c5163053b/config/initializers/samvera_config.rb#L32-L35).
 
 ## Considerations
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ The Samvera::NestingIndexer gem is responsible for indexing the graph relationsh
 
 This is a sandbox to work through the reindexing strategy as it relates to [CurateND Collections](https://github.com/ndlib/samvera_nd/issues/420). At this point the code is separate to allow for raid testing and prototyping (no sense spinning up SOLR and Fedora to walk an arbitrary graph).
 
+### Notation
+
+When B is a member of A, I am using the `A ={ B` notation. When C is a member of B and B is a member of A, I'll chain these together `A ={ B ={ C`.
+
 ## Concepts
 
 As we are indexing objects, we have two types of documents:

--- a/lib/samvera/nesting_indexer.rb
+++ b/lib/samvera/nesting_indexer.rb
@@ -13,9 +13,12 @@ module Samvera
     # In a perfect world we could reindex the id as well; But that is for another test.
     #
     # @param id [String] - The permanent identifier of the object that will be reindexed along with its children.
-    # @param maximum_nesting_depth [Integer] - there to guard against cyclical graphs
+    # @param maximum_nesting_depth [Integer] - used to short-circuit overly deep nesting as well as prevent accidental cyclic graphs
+    #                                          from creating an infinite loop.
     # @return [Boolean] - It was successful
-    # @raise Samvera::Exceptions::CycleDetectionError - A potential cycle was detected
+    # @raise Samvera::Exceptions::CycleDetectionError - A possible cycle was detected
+    # @raise Samvera::Exceptions::ExceededMaximumNestingDepthError - We exceeded our maximum depth
+    # @raise Samvera::Exceptions::DocumentIsItsOwnAncestorError - A document we were about to index appeared to be its own ancestor
     def self.reindex_relationships(id:, maximum_nesting_depth: configuration.maximum_nesting_depth)
       RelationshipReindexer.call(id: id, maximum_nesting_depth: maximum_nesting_depth, configuration: configuration)
       true
@@ -29,9 +32,9 @@ module Samvera
 
     # @api public
     # Responsible for reindexing the entire preservation layer.
-    # @param maximum_nesting_depth [Integer] - there to guard against cyclical graphs
+    # @param maximum_nesting_depth [Integer] - there to guard against cyclic graphs
     # @return [Boolean] - It was successful
-    # @raise Samvera::Exceptions::CycleDetectionError - A potential cycle was detected
+    # @raise Samvera::Exceptions::ReindexingError - There was a problem reindexing the graph.
     def self.reindex_all!(maximum_nesting_depth: configuration.maximum_nesting_depth)
       # While the RepositoryReindexer is responsible for reindexing everything, I
       # want to inject the lambda that will reindex a single item.

--- a/lib/samvera/nesting_indexer.rb
+++ b/lib/samvera/nesting_indexer.rb
@@ -17,7 +17,7 @@ module Samvera
     # @return [Boolean] - It was successful
     # @raise Samvera::Exceptions::CycleDetectionError - A potential cycle was detected
     def self.reindex_relationships(id:, maximum_nesting_depth: configuration.maximum_nesting_depth)
-      RelationshipReindexer.call(id: id, maximum_nesting_depth: maximum_nesting_depth, adapter: adapter)
+      RelationshipReindexer.call(id: id, maximum_nesting_depth: maximum_nesting_depth, configuration: configuration)
       true
     end
 
@@ -36,7 +36,7 @@ module Samvera
       # While the RepositoryReindexer is responsible for reindexing everything, I
       # want to inject the lambda that will reindex a single item.
       id_reindexer = method(:reindex_relationships)
-      RepositoryReindexer.call(maximum_nesting_depth: maximum_nesting_depth, id_reindexer: id_reindexer, adapter: adapter)
+      RepositoryReindexer.call(maximum_nesting_depth: maximum_nesting_depth, id_reindexer: id_reindexer, configuration: configuration)
       true
     end
 

--- a/lib/samvera/nesting_indexer/adapters/in_memory_adapter.rb
+++ b/lib/samvera/nesting_indexer/adapters/in_memory_adapter.rb
@@ -88,7 +88,7 @@ module Samvera
           end
 
           def find_each
-            cache.each { |_key, document| yield(document) }
+            cache.each_value { |document| yield(document) }
           end
 
           def clear_cache!

--- a/lib/samvera/nesting_indexer/adapters/interface_behavior_spec.rb
+++ b/lib/samvera/nesting_indexer/adapters/interface_behavior_spec.rb
@@ -61,7 +61,7 @@ if defined?(RSpec)
       end
 
       it 'expects a block' do
-        expect(block_parameter_extracter.call(subject)).to be_present
+        expect(block_parameter_extracter.call(subject)).to eq([:block])
       end
     end
     describe '.each_child_document_of' do
@@ -76,13 +76,13 @@ if defined?(RSpec)
       end
 
       it 'expects a block' do
-        expect(block_parameter_extracter.call(subject)).to be_present
+        expect(block_parameter_extracter.call(subject)).to eq([:block])
       end
     end
     describe '.write_document_attributes_to_index_layer' do
       subject { described_class.method(:write_document_attributes_to_index_layer) }
 
-      it 'requires the :attributes keyword (and does not require any others)' do
+      it 'requires the :ancestors, :id, :parent_ids, and :pathnames keyword (and does not require any others)' do
         expect(required_keyword_parameters.call(subject)).to eq(%i(ancestors id parent_ids pathnames))
       end
 

--- a/lib/samvera/nesting_indexer/configuration.rb
+++ b/lib/samvera/nesting_indexer/configuration.rb
@@ -1,5 +1,6 @@
 require 'samvera/nesting_indexer/adapters/abstract_adapter'
 require 'samvera/nesting_indexer/exceptions'
+require 'logger'
 
 module Samvera
   # :nodoc:
@@ -9,11 +10,14 @@ module Samvera
     class Configuration
       DEFAULT_MAXIMUM_NESTING_DEPTH = 15
 
-      def initialize(maximum_nesting_depth: DEFAULT_MAXIMUM_NESTING_DEPTH)
+      def initialize(maximum_nesting_depth: DEFAULT_MAXIMUM_NESTING_DEPTH, logger: default_logger)
         self.maximum_nesting_depth = maximum_nesting_depth
+        self.logger = logger
       end
 
-      attr_reader :maximum_nesting_depth
+      attr_reader :maximum_nesting_depth, :logger
+
+      attr_writer :logger
 
       def maximum_nesting_depth=(input)
         @maximum_nesting_depth = input.to_i
@@ -67,6 +71,14 @@ module Samvera
         $stdout.puts IN_MEMORY_ADAPTER_WARNING_MESSAGE unless defined?(SUPPRESS_MEMORY_ADAPTER_WARNING)
         require 'samvera/nesting_indexer/adapters/in_memory_adapter'
         Adapters::InMemoryAdapter
+      end
+
+      def default_logger
+        if defined?(Rails.logger)
+          Rails.logger
+        else
+          Logger.new($stdout)
+        end
       end
     end
     private_constant :Configuration

--- a/lib/samvera/nesting_indexer/documents.rb
+++ b/lib/samvera/nesting_indexer/documents.rb
@@ -3,6 +3,8 @@ require 'dry-equalizer'
 module Samvera
   module NestingIndexer
     module Documents
+      ANCESTOR_AND_PATHNAME_DELIMITER = '/'.freeze
+
       # @api public
       #
       # A simplified document that reflects the necessary attributes for re-indexing

--- a/lib/samvera/nesting_indexer/exceptions.rb
+++ b/lib/samvera/nesting_indexer/exceptions.rb
@@ -30,9 +30,26 @@ module Samvera
       # Raised when we may have detected a cycle within the graph
       class CycleDetectionError < RuntimeError
         attr_reader :id
-        def initialize(id)
+        def initialize(id:)
           @id = id
-          super "Possible graph cycle discovered related to PID=#{id}."
+          super to_s
+        end
+
+        def to_s
+          "Possible graph cycle discovered related to ID=#{id.inspect}."
+        end
+      end
+
+      # Raised when we encounter a document that is to be indexed as its own ancestor.
+      class DocumentIsItsOwnAncestorError < CycleDetectionError
+        attr_reader :pathnames
+        def initialize(id:, pathnames:)
+          super(id: id)
+          @pathnames = pathnames
+        end
+
+        def to_s
+          "Document with ID=#{id.inspect} is marked as its own ancestor based on the given pathnames: #{pathnames.inspect}."
         end
       end
       # A wrapper exception that includes the original exception and the id

--- a/lib/samvera/nesting_indexer/exceptions.rb
+++ b/lib/samvera/nesting_indexer/exceptions.rb
@@ -41,7 +41,7 @@ module Samvera
         def initialize(id, original_exception)
           @id = id
           @original_exception = original_exception
-          super "Error PID=#{id} - #{original_exception}"
+          super "ReindexingError on ID=#{id.inspect}\n\t#{original_exception}"
         end
       end
     end

--- a/lib/samvera/nesting_indexer/exceptions.rb
+++ b/lib/samvera/nesting_indexer/exceptions.rb
@@ -40,6 +40,14 @@ module Samvera
         end
       end
 
+      # Raised when we have exceeded the time to live constraint
+      # @see Samvera::NestingIndexer::Configuration.maximum_nesting_depth
+      class ExceededMaximumNestingDepthError < CycleDetectionError
+        def to_s
+          "Exceeded maximum nesting depth while indexing ID=#{id.inspect}."
+        end
+      end
+
       # Raised when we encounter a document that is to be indexed as its own ancestor.
       class DocumentIsItsOwnAncestorError < CycleDetectionError
         attr_reader :pathnames

--- a/lib/samvera/nesting_indexer/relationship_reindexer.rb
+++ b/lib/samvera/nesting_indexer/relationship_reindexer.rb
@@ -128,9 +128,9 @@ module Samvera
         def compile_one!(parent_index_document)
           @parent_ids << parent_index_document.id
           parent_index_document.pathnames.each do |pathname|
-            @pathnames << File.join(pathname, @preservation_document.id)
-            slugs = pathname.split("/")
-            slugs.each_index { |i| @ancestors << slugs[0..i].join('/') }
+            @pathnames << "#{pathname}#{Documents::ANCESTOR_AND_PATHNAME_DELIMITER}#{@preservation_document.id}"
+            slugs = pathname.split(Documents::ANCESTOR_AND_PATHNAME_DELIMITER)
+            slugs.each_index { |i| @ancestors << slugs[0..i].join(Documents::ANCESTOR_AND_PATHNAME_DELIMITER) }
           end
           @ancestors += parent_index_document.ancestors
         end

--- a/lib/samvera/nesting_indexer/relationship_reindexer.rb
+++ b/lib/samvera/nesting_indexer/relationship_reindexer.rb
@@ -6,7 +6,7 @@ module Samvera
   # Establishing namespace
   module NestingIndexer
     # Responsible for reindexing the PID and its descendants
-    # @note There is cycle detection via the TIME_TO_LIVE counter
+    # @note There is cycle detection via the Samvera::NestingIndexer::Configuration#maximum_nesting_depth counter
     # @api private
     class RelationshipReindexer
       # @api private
@@ -20,7 +20,7 @@ module Samvera
       end
 
       # @param id [String]
-      # @param maximum_nesting_depth [Integer] Samvera::NestingIndexer::TIME_TO_LIVE to detect cycles in the graph
+      # @param maximum_nesting_depth [Integer] What is the maximum allowed depth of nesting
       # @param configuration [#adapter, #logger] The :adapter conforms to the Samvera::NestingIndexer::Adapters::AbstractAdapter interface
       #                                          and the :logger conforms to Logger
       # @param queue [#shift, #push] queue
@@ -77,7 +77,7 @@ module Samvera
       end
 
       def process_a_document(index_document)
-        raise Exceptions::CycleDetectionError, id: id if index_document.maximum_nesting_depth <= 0
+        raise Exceptions::ExceededMaximumNestingDepthError, id: id if index_document.maximum_nesting_depth <= 0
         wrap_logging("indexing ID=#{index_document.id.inspect}") do
           preservation_document = adapter.find_preservation_document_by(id: index_document.id)
           parent_ids_and_path_and_ancestors = parent_ids_and_path_and_ancestors_for(preservation_document)

--- a/lib/samvera/nesting_indexer/relationship_reindexer.rb
+++ b/lib/samvera/nesting_indexer/relationship_reindexer.rb
@@ -21,15 +21,16 @@ module Samvera
 
       # @param id [String]
       # @param maximum_nesting_depth [Integer] Samvera::NestingIndexer::TIME_TO_LIVE to detect cycles in the graph
-      # @param adapter [Samvera::NestingIndexer::Adapters::AbstractAdapter] Conforms to the Samvera::NestingIndexer::Adapters::AbstractAdapter interface
+      # @param configuration [#adapter, #logger] The :adapter conforms to the Samvera::NestingIndexer::Adapters::AbstractAdapter interface
+      #                                          and the :logger conforms to Logger
       # @param queue [#shift, #push] queue
-      def initialize(id:, maximum_nesting_depth:, adapter:, queue: [])
+      def initialize(id:, maximum_nesting_depth:, configuration:, queue: [])
         @id = id.to_s
         @maximum_nesting_depth = maximum_nesting_depth.to_i
-        @adapter = adapter
+        @configuration = configuration
         @queue = queue
       end
-      attr_reader :id, :maximum_nesting_depth, :queue, :adapter
+      attr_reader :id, :maximum_nesting_depth
 
       # Perform a bread-first tree traversal of the initial document and its descendants.
       def call
@@ -45,6 +46,7 @@ module Samvera
 
       private
 
+      attr_reader :queue, :configuration
       attr_writer :document
 
       def initial_index_document
@@ -53,6 +55,8 @@ module Samvera
 
       extend Forwardable
       def_delegator :queue, :shift, :dequeue
+      def_delegator :configuration, :adapter
+      def_delegator :configuration, :logger
 
       require 'delegate'
       # A small object to help track time to live concerns

--- a/lib/samvera/nesting_indexer/relationship_reindexer.rb
+++ b/lib/samvera/nesting_indexer/relationship_reindexer.rb
@@ -51,7 +51,6 @@ module Samvera
       private
 
       attr_reader :queue, :configuration
-      attr_writer :document
 
       def initial_index_document
         adapter.find_index_document_by(id: id)

--- a/lib/samvera/nesting_indexer/repository_reindexer.rb
+++ b/lib/samvera/nesting_indexer/repository_reindexer.rb
@@ -54,7 +54,7 @@ module Samvera
       # walk up the parent graph to reindex the parents before we start on the child.
       def recursive_reindex(id:, parent_ids:, time_to_live:)
         return true if processed_ids.include?(id)
-        raise Exceptions::CycleDetectionError, id if time_to_live <= 0
+        raise Exceptions::CycleDetectionError, id: id if time_to_live <= 0
         parent_ids.each do |parent_id|
           grand_parent_ids = adapter.find_preservation_parent_ids_for(id: parent_id)
           recursive_reindex(id: parent_id, parent_ids: grand_parent_ids, time_to_live: maximum_nesting_depth - 1)

--- a/lib/samvera/nesting_indexer/repository_reindexer.rb
+++ b/lib/samvera/nesting_indexer/repository_reindexer.rb
@@ -54,7 +54,7 @@ module Samvera
       # walk up the parent graph to reindex the parents before we start on the child.
       def recursive_reindex(id:, parent_ids:, time_to_live:)
         return true if processed_ids.include?(id)
-        raise Exceptions::CycleDetectionError, id: id if time_to_live <= 0
+        raise Exceptions::ExceededMaximumNestingDepthError, id: id if time_to_live <= 0
         parent_ids.each do |parent_id|
           grand_parent_ids = adapter.find_preservation_parent_ids_for(id: parent_id)
           recursive_reindex(id: parent_id, parent_ids: grand_parent_ids, time_to_live: maximum_nesting_depth - 1)
@@ -66,6 +66,7 @@ module Samvera
         id_reindexer.call(id: id)
         processed_ids << id
       rescue StandardError => e
+        logger.error(e)
         raise Exceptions::ReindexingError.new(id, e)
       end
     end

--- a/lib/samvera/nesting_indexer/repository_reindexer.rb
+++ b/lib/samvera/nesting_indexer/repository_reindexer.rb
@@ -1,3 +1,5 @@
+require 'samvera/nesting_indexer/exceptions'
+require 'forwardable'
 module Samvera
   # Establishing namespace
   module NestingIndexer

--- a/spec/features/reindex_pid_and_descendants_spec.rb
+++ b/spec/features/reindex_pid_and_descendants_spec.rb
@@ -15,7 +15,7 @@ module Samvera
 
       def build_graph(graph)
         # Create the starting_graph
-        graph.fetch(:parent_ids).keys.each do |id|
+        graph.fetch(:parent_ids).each_key do |id|
           build_preservation_document(id, graph)
           build_index_document(id, graph)
         end
@@ -134,7 +134,7 @@ module Samvera
       end
 
       def verify_graph_versus_storage(ending_graph)
-        ending_graph.fetch(:parent_ids).keys.each do |id|
+        ending_graph.fetch(:parent_ids).each_key do |id|
           verify_graph_item_versus_storage(id, ending_graph)
         end
       end

--- a/spec/features/reindex_pid_and_descendants_spec.rb
+++ b/spec/features/reindex_pid_and_descendants_spec.rb
@@ -161,7 +161,7 @@ module Samvera
           expect { NestingIndexer.reindex_relationships(id: :a) }.to raise_error(Exceptions::CycleDetectionError)
         end
 
-        it 'catches a simple cyclical graph (start with A ={ B and add B ={ A relationship)' do
+        it 'catches a simple cyclic graph (start with A ={ B and add B ={ A relationship)' do
           starting_graph = {
             parent_ids: { a: [], b: ['a'] }
           }
@@ -176,7 +176,7 @@ module Samvera
           }
           verify_graph_versus_storage(ending_graph)
 
-          # We are writing (and succeeding at writing) a cyclical relationship
+          # We are writing (and succeeding at writing) a cyclic relationship
           NestingIndexer.adapter.write_document_attributes_to_preservation_layer(id: :a, parent_ids: ['b'])
           expect { NestingIndexer.reindex_relationships(id: :a) }.to raise_error(Samvera::NestingIndexer::Exceptions::DocumentIsItsOwnAncestorError)
 
@@ -184,7 +184,7 @@ module Samvera
           verify_graph_versus_storage(ending_graph)
         end
 
-        it 'catches a simple cyclical graph (start with A ={ B ={ C and add C ={ B relationship)' do
+        it 'catches a simple cyclic graph (start with A ={ B ={ C and add C ={ B relationship)' do
           starting_graph = {
             parent_ids: { a: [], b: ['a'], c: ['b'] }
           }
@@ -199,7 +199,7 @@ module Samvera
           }
           verify_graph_versus_storage(ending_graph)
 
-          # We are writing (and succeeding at writing) a cyclical relationship
+          # We are writing (and succeeding at writing) a cyclic relationship
           NestingIndexer.adapter.write_document_attributes_to_preservation_layer(id: :b, parent_ids: ['a', 'c'])
           expect { NestingIndexer.reindex_relationships(id: :b) }.to raise_error(Samvera::NestingIndexer::Exceptions::DocumentIsItsOwnAncestorError)
 
@@ -207,7 +207,7 @@ module Samvera
           verify_graph_versus_storage(ending_graph)
         end
 
-        it 'catches a simple cyclical graph (start with A ={ B ={ C and add C ={ B relationship)' do
+        it 'catches a simple cyclic graph (start with A ={ B ={ C and add C ={ B relationship)' do
           starting_graph = {
             parent_ids: { a: [], b: ['a'], c: ['b'], d: ['c'] }
           }
@@ -245,7 +245,7 @@ module Samvera
           verify_graph_versus_storage(ending_graph)
         end
 
-        it 'indexes a non-cyclical graph' do
+        it 'indexes a non-cyclic graph' do
           starting_graph = {
             parent_ids: { a: [], b: ['a'], c: ['a', 'b'], d: ['b'], e: ['c', 'd'], f: [] }
           }
@@ -261,7 +261,7 @@ module Samvera
           verify_graph_versus_storage(ending_graph)
         end
 
-        it 'indexes a non-cyclical graph not declared in parent order' do
+        it 'indexes a non-cyclic graph not declared in parent order' do
           starting_graph = {
             parent_ids: { a: ['b'], b: ['c'], c: [] }
           }
@@ -277,7 +277,7 @@ module Samvera
           verify_graph_versus_storage(ending_graph)
         end
 
-        it 'catches a cyclical graph definition' do
+        it 'catches a cyclic graph definition' do
           starting_graph = {
             parent_ids: { a: [], b: ['a', 'd'], c: ['b'], d: ['c'] }
           }

--- a/spec/lib/samvera/nesting_indexer/configuration_spec.rb
+++ b/spec/lib/samvera/nesting_indexer/configuration_spec.rb
@@ -12,6 +12,42 @@ module Samvera
         it { is_expected.to be_a(Integer) }
       end
 
+      describe '#logger' do
+        before { Object.send(:remove_const, :Rails) if defined?(Rails) }
+        describe 'by default' do
+          describe 'with Rails defined' do
+            before do
+              # rubocop:disable Style/ClassAndModuleChildren
+              module ::Rails
+                def self.logger
+                  :logger
+                end
+              end
+              # rubocop:enable Style/ClassAndModuleChildren
+            end
+            after do
+              Object.send(:remove_const, :Rails) if defined?(Rails)
+            end
+            it 'uses the existing Rails logger' do
+              subject = described_class.new
+              expect(subject.logger).to eq(Rails.logger)
+            end
+          end
+          describe 'without Rails defined' do
+            it 'uses a simple Logger that writes to STDOUT' do
+              subject = described_class.new
+              expect(defined?(Rails)).to be_falsey
+              expect(subject.logger).to be_a(Logger)
+            end
+          end
+        end
+        it 'can be overridden' do
+          logger = double('logger')
+          subject = described_class.new
+          expect { subject.logger = logger }.to change { subject.logger }.to(logger)
+        end
+      end
+
       describe '#solr_field_name_for_storing_parent_ids' do
         subject { configuration.solr_field_name_for_storing_parent_ids }
 

--- a/spec/lib/samvera/nesting_indexer/exceptions_spec.rb
+++ b/spec/lib/samvera/nesting_indexer/exceptions_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+require 'samvera/nesting_indexer/exceptions'
+
+module Samvera
+  module NestingIndexer
+    module Exceptions
+      RSpec.describe CycleDetectionError do
+        subject { described_class.new(id: 123) }
+        its(:to_s) { is_expected.to be_a(String) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
The goal of this pull request is to detect self-ancestry earlier in the process. Prior to this PR, we relied on a time to live (via maximum depth) to find cycles in the graph. With this change we introduce another guard.

## Appeasing the latest Rubocop

338dd05

The following violations were discovered on Travis but not locally.
Which meant I had an older version of Rubocop on my machine.

```console
lib/samvera/nesting_indexer/adapters/in_memory_adapter.rb:91:19: C:
  Performance/HashEachMethods: Use each_value instead of each.
            cache.each { |_key, document| yield(document) }
                  ^^^^
spec/features/reindex_pid_and_descendants_spec.rb:18:34: C:
  Performance/HashEachMethods: Use each_key instead of keys.each.
        graph.fetch(:parent_ids).keys.each do |id|
                                 ^^^^^^^^^
spec/features/reindex_pid_and_descendants_spec.rb:137:41: C:
  Performance/HashEachMethods: Use each_key instead of keys.each.
        ending_graph.fetch(:parent_ids).keys.each do |id|
                                        ^^^^^^^^^
```

## Updating specs and documentation

61591be

I'm adding a bit more clarity in behavior, also ensuring that necessary
requires are called as well.

## Adding ability to specify a logger

9aac7cf

As I was debugging processes I found it helpful to have a logger. I
exposed a configurable logger with the idea that this would be very
helpful in troubleshooting what might be happening.

## Adding additional examples and clarifications

3e1537a835ef7d4f638d308bd5ec218b7ee826c8

I'm including notations for membership to ensure a common understanding
of language. Then adding a few more tests that highlight updating a
document into a cyclical state.

This does not resolve the larger problem of relying on the time to live
to kill the indexing process instead of checking within that time to
live for a cyclical graph.

## Adding logging to reindexing

1663a813ee238322cd8b87f606a7cc859f6bb733

I'm working through some reindexing scenarios and have struggled with
following the path. By adding logging I hope to have a better chance of
following the algorithm's course.

## Removing `attr_writer :document`

bc5f10da87b30881ee530b9f567645b32b3a1629

I did some digging at I believe at one point I was passing the document
instead of the id. However, that is no longer the behavior and means
the `#document=` method is unneeded.

## Ensuring we use the same pathname separator

ecacf5724fb8b38e1d585d27ce97f90c759c3bed

It is possible one machine would use a different separator in
`File.join` when indexing and processing. This change ensures we have
the same separator across different machines.

## Adding detection for indexing self ancestry

337ee2edc089be744fed9ab792b040c258176344

Prior to this commit, we relied on the time to live enforcing cycles.
The reality, however, is that if we had the following:

> A ={ B ={ C ={ B

We would be updating the index document multiple times and adding a
pathname of the following form: "A/B/C/B/C/B/C". This code short-
circuits that and hopefully keeps the index in a better state.

Beware the Delta Wave http://futurama.wikia.com/wiki/Delta_Brainwave

## Updating documentation to clarify behavior

8bb7492456ab73896b978904476b9410a4acada2

The change also includes extracting another exception subclass to
better clarify why something failed.
