### PR TITLE
Clarifying documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,15 @@ We have four attributes to consider for indexing the graph:
 1. id - the unique identifier for a document
 2. parent_ids - the ids for all of the parents of a given document
 3. pathnames - the paths to traverse from a root document to the given document
-4. ancestors - the pathnames of each of the ancestors
+4. ancestors - the pathnames to each node that is an ancestor of the given node (e.g. pathname to my parent, pathname to my grandparent)
 
 See [Samvera::NestingIndexer::Documents::IndexDocument](./lib/samvera/nesting_indexer/documents.rb) for further discussion.
 
 To reindex a single document, we leverage the [`Samvera::NestingIndexer.reindex_relationships`](./lib/samvera/nesting_indexer.rb) method.
 
 To reindex all of the documents, we leverage the [`Samvera::NestingIndexer.reindex_all!`](lib/samvera/nesting_indexer.rb) method. **Warning: This is a very slow process.**
+
+With a node's pathname(s), we are able to query what are all of my descendants (both direct and indirect) by way of the ancestors.
 
 ## Examples
 
@@ -53,18 +55,23 @@ Given the following PreservationDocuments:
 | C   | A       |
 | D   | A, B    |
 | E   | C       |
+| F   | D       |
 
 If we were to reindex the above PreservationDocuments, we will generate the following IndexDocuments:
 
-| PID | Parents | Pathnames  | Ancestors |
-|-----|---------|------------|-----------|
-| A   | -       | [A]        | []        |
-| B   | -       | [B]        | []        |
-| C   | A       | [A/C]      | [A]       |
-| D   | A, B    | [A/D, B/D] | [A, B]    |
-| E   | C       | [A/C/E]    | [A/C]     |
+| PID | Parents | Pathnames      | Ancestors        |
+|-----|---------|----------------|------------------|
+| A   | -       | [A]            | []               |
+| B   | -       | [B]            | []               |
+| C   | A       | [A/C]          | [A]              |
+| D   | A, B    | [A/D, B/D]     | [A, B]           |
+| E   | C       | [A/C/E]        | [A, A/C]         |
+| F   | D       | [A/D/F, B/D/F] | [A, A/D, B, B/D] |
 
 For more scenarios, look at the [Reindex PID and Descendants specs](./spec/features/reindex_id_and_descendants_spec.rb).
+
+* Given I want to find the direct descendants of A, then I can query all nodes with that have a parent of A.
+* Given I want to find the direct and indirect descendants of A, then I can query all notes that have an ancestor entry of A.
 
 ## Adapters
 

--- a/lib/samvera/nesting_indexer/relationship_reindexer.rb
+++ b/lib/samvera/nesting_indexer/relationship_reindexer.rb
@@ -145,7 +145,9 @@ module Samvera
           parent_index_document.pathnames.each do |pathname|
             @pathnames << "#{pathname}#{Documents::ANCESTOR_AND_PATHNAME_DELIMITER}#{@preservation_document.id}"
             slugs = pathname.split(Documents::ANCESTOR_AND_PATHNAME_DELIMITER)
-            slugs.each_index { |i| @ancestors << slugs[0..i].join(Documents::ANCESTOR_AND_PATHNAME_DELIMITER) }
+            slugs.each_index do |i|
+              @ancestors << slugs[0..i].join(Documents::ANCESTOR_AND_PATHNAME_DELIMITER)
+            end
           end
           @ancestors += parent_index_document.ancestors
         end

--- a/spec/features/reindex_pid_and_descendants_spec.rb
+++ b/spec/features/reindex_pid_and_descendants_spec.rb
@@ -79,6 +79,23 @@ module Samvera
                 f: ['g/b/e/f', 'g/b/c/e/f', 'a/c/e/f'], g: ['g']
               }
             }
+          }, {
+            name: 'Nesting one nested set of nodes within another node',
+            starting_graph: {
+              parent_ids: { pnc: [], pub_gw: ['pnc'], pc: [], auth_gw: ['pc'], cc: ['pc'], priv_gw: ['cc'] },
+              ancestors: { pnc: [], pub_gw: ['pnc'], pc: [], auth_gw: ['pc'], cc: ['pc'], priv_gw: ['pc/cc', 'pc'] },
+              pathnames: {
+                pnc: ['pnc'], pub_gw: ['pnc/pub_gw'], pc: ['pc'], auth_gw: ['pc/auth_gw'], cc: ['pc/cc'], priv_gw: ['pc/cc/priv_gw']
+              }
+            },
+            preservation_document_attributes_to_update: { id: :pc, parent_ids: ['pnc'] },
+            ending_graph: {
+              parent_ids: { pnc: [], pub_gw: ['pnc'], pc: ['pnc'], auth_gw: ['pc'], cc: ['pc'], priv_gw: ['cc'] },
+              ancestors: { pnc: [], pub_gw: ['pnc'], pc: ['pnc'], auth_gw: ['pnc', 'pnc/pc'], cc: ['pnc', 'pnc/pc'], priv_gw: ['pnc', 'pnc/pc', 'pnc/pc/cc'] },
+              pathnames: {
+                pnc: ['pnc'], pub_gw: ['pnc/pub_gw'], pc: ['pnc/pc'], auth_gw: ['pnc/pc/auth_gw'], cc: ['pnc/pc/cc'], priv_gw: ['pnc/pc/cc/priv_gw']
+              }
+            }
           }
         ].each_with_index do |the_scenario, index|
           context "#{the_scenario.fetch(:name)} (Scenario #{index})" do
@@ -194,6 +211,22 @@ module Samvera
               a: ['a'], b: ['a/b'], c: ['a/c', 'a/b/c'], d: ['a/b/d', 'a/b/c/d', 'a/c/d'], e: ['a/b/e', 'a/b/c/e', 'a/c/e'],
               f: ['a/b/e/f', 'a/b/c/e/f', 'a/c/e/f'], g: ['g']
             }
+          }
+          verify_graph_versus_storage(ending_graph)
+        end
+
+        it 'verifying the structure of ancestors' do
+          starting_graph = {
+            parent_ids: { a: [], b: ['a'], c: ['b', 'e'], d: [], e: ['d'] }
+          }
+          build_graph(starting_graph)
+
+          NestingIndexer.reindex_all!
+
+          ending_graph = {
+            parent_ids: { a: [], b: ['a'], c: ['b', 'e'], d: [], e: ['d'] },
+            ancestors: { a: [], b: ['a'], c: ['a', 'a/b', 'd', 'd/e'], d: [], e: ['d'] },
+            pathnames: { a: ['a'], b: ['a/b'], c: ['a/b/c', 'd/e/c'], d: ['d'], e: ['d/e'] }
           }
           verify_graph_versus_storage(ending_graph)
         end


### PR DESCRIPTION
The documentation varied from the specs. In reviewing the specs and
intentions, both the documentation and the specs are now in alignment.

This also involved clarifying the ancestors field which was a bit
ambiguous (given the prior documentation).