### PR TITLE
Cache deepest nested level

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ In implementations, you'll likely want to write a queries that answer:
 
 ## TODO
 
-- [ ] Incorporate additional logging
+- [X] Incorporate additional logging
 - [ ] Build methods to allow for fanning out the reindexing. At present, when we reindex a node and its "children", we run that entire process within a single context. Likewise, we run a single process when reindexing EVERYTHING.
 - [ ] Promote from [samvera-labs](https://github.com/samvera-labs) to [samvera](https://github.com/samvera) via the [promotion process](http://samvera-labs.github.io/promotion.html).
 - [ ] Write adapter method to assist in guarding against self-ancestry. We could probably expose a base adapter that has the method through use of the other adapter methods.

--- a/lib/samvera/nesting_indexer/adapters/abstract_adapter.rb
+++ b/lib/samvera/nesting_indexer/adapters/abstract_adapter.rb
@@ -43,6 +43,7 @@ module Samvera
         end
 
         # @api public
+        # @deprecated Use .write_nesting_document_to_index_layer instead
         # @see README.md
         # @param id [String]
         # @param parent_ids [Array<String>]
@@ -51,6 +52,15 @@ module Samvera
         # @param deepest_nested_depth [Integer]
         # @return Hash - the attributes written to the indexing layer
         def self.write_document_attributes_to_index_layer(id:, parent_ids:, ancestors:, pathnames:, deepest_nested_depth:)
+          raise NotImplementedError
+        end
+
+        # @api public
+        # @since v1.0.0
+        # @see README.md
+        # @param nesting_document [Samvera::NestingIndexer::Document::IndexDocument]
+        # @return void
+        def self.write_nesting_document_to_index_layer(nesting_document:)
           raise NotImplementedError
         end
       end

--- a/lib/samvera/nesting_indexer/adapters/abstract_adapter.rb
+++ b/lib/samvera/nesting_indexer/adapters/abstract_adapter.rb
@@ -48,8 +48,9 @@ module Samvera
         # @param parent_ids [Array<String>]
         # @param ancestors [Array<String>]
         # @param pathnames [Array<String>]
+        # @param deepest_nested_depth [Integer]
         # @return Hash - the attributes written to the indexing layer
-        def self.write_document_attributes_to_index_layer(id:, parent_ids:, ancestors:, pathnames:)
+        def self.write_document_attributes_to_index_layer(id:, parent_ids:, ancestors:, pathnames:, deepest_nested_depth:)
           raise NotImplementedError
         end
       end

--- a/lib/samvera/nesting_indexer/adapters/in_memory_adapter.rb
+++ b/lib/samvera/nesting_indexer/adapters/in_memory_adapter.rb
@@ -59,9 +59,10 @@ module Samvera
         # @param parent_ids [Array<String>]
         # @param ancestors [Array<String>]
         # @param pathnames [Array<String>]
+        # @param deepest_nested_depth [Integer]
         # @return [Hash] - the attributes written to the indexing layer
-        def self.write_document_attributes_to_index_layer(id:, parent_ids:, ancestors:, pathnames:)
-          Index.write_document(id: id, parent_ids: parent_ids, ancestors: ancestors, pathnames: pathnames)
+        def self.write_document_attributes_to_index_layer(id:, parent_ids:, ancestors:, pathnames:, deepest_nested_depth:)
+          Index.write_document(id: id, parent_ids: parent_ids, ancestors: ancestors, pathnames: pathnames, deepest_nested_depth: deepest_nested_depth)
         end
 
         # @api private

--- a/lib/samvera/nesting_indexer/adapters/in_memory_adapter.rb
+++ b/lib/samvera/nesting_indexer/adapters/in_memory_adapter.rb
@@ -65,6 +65,13 @@ module Samvera
           Index.write_document(id: id, parent_ids: parent_ids, ancestors: ancestors, pathnames: pathnames, deepest_nested_depth: deepest_nested_depth)
         end
 
+        # @api public
+        # @see README.md
+        # @param nesting_document [Samvera::NestingIndexer::Documents::IndexDocument]
+        def self.write_nesting_document_to_index_layer(nesting_document:)
+          Index.write_to_storage(nesting_document)
+        end
+
         # @api private
         def self.clear_cache!
           Preservation.clear_cache!
@@ -161,8 +168,12 @@ module Samvera
             Storage.find_children_of_id(document.id).each(&block)
           end
 
+          def self.write_to_storage(doc)
+            Storage.write(doc)
+          end
+
           def self.write_document(attributes = {})
-            Documents::IndexDocument.new(attributes).tap { |doc| Storage.write(doc) }
+            Documents::IndexDocument.new(attributes).tap { |doc| write_to_storage(doc) }
           end
 
           # :nodoc:

--- a/lib/samvera/nesting_indexer/adapters/interface_behavior_spec.rb
+++ b/lib/samvera/nesting_indexer/adapters/interface_behavior_spec.rb
@@ -82,8 +82,8 @@ if defined?(RSpec)
     describe '.write_document_attributes_to_index_layer' do
       subject { described_class.method(:write_document_attributes_to_index_layer) }
 
-      it 'requires the :ancestors, :id, :parent_ids, and :pathnames keyword (and does not require any others)' do
-        expect(required_keyword_parameters.call(subject)).to eq(%i(ancestors id parent_ids pathnames))
+      it 'requires the :ancestors, :deepest_nested_depth, :id, :parent_ids, and :pathnames keyword (and does not require any others)' do
+        expect(required_keyword_parameters.call(subject)).to eq(%i(ancestors deepest_nested_depth id parent_ids pathnames))
       end
 
       it 'does not require any other parameters (besides :attributes)' do

--- a/lib/samvera/nesting_indexer/adapters/interface_behavior_spec.rb
+++ b/lib/samvera/nesting_indexer/adapters/interface_behavior_spec.rb
@@ -94,5 +94,21 @@ if defined?(RSpec)
         expect(block_parameter_extracter.call(subject)).to be_empty
       end
     end
+
+    describe '.write_nesting_document_to_index_layer' do
+      subject { described_class.method(:write_nesting_document_to_index_layer) }
+
+      it 'requires the :nesting_document' do
+        expect(required_keyword_parameters.call(subject)).to eq(%i(nesting_document))
+      end
+
+      it 'does not require any other parameters' do
+        expect(required_parameters.call(subject)).to eq(required_keyword_parameters.call(subject))
+      end
+
+      it 'does not expect a block' do
+        expect(block_parameter_extracter.call(subject)).to be_empty
+      end
+    end
   end
 end

--- a/lib/samvera/nesting_indexer/documents.rb
+++ b/lib/samvera/nesting_indexer/documents.rb
@@ -43,6 +43,19 @@ module Samvera
         end
 
         # @api public
+        # @since v1.0.0
+        # @return [Hash<Symbol,>] the Ruby hash representation of this index document.
+        def to_hash
+          {
+            id: id,
+            parent_ids: parent_ids,
+            pathnames: pathnames,
+            ancestors: ancestors,
+            deepest_nested_depth: deepest_nested_depth
+          }
+        end
+
+        # @api public
         # @return String The Fedora object's PID
         attr_reader :id
 
@@ -70,10 +83,21 @@ module Samvera
         #
         # All of the :pathnames of each of the documents ancestors. If I have A, with parent B, and B has
         # parents C and D then we have the following ancestors:
-        #   [D/B], [C/B]
+        #   [D], [C], [D/B], [C/B]
         #
         # @return Array<String>
         attr_reader :ancestors
+
+        # @api public
+        # @since v1.0.0
+        #
+        # The largest nesting depth of this document. If I have A ={ B ={ C and D ={ C, then
+        # deepest_nested_depth is 3.
+        #
+        # @return Integer
+        def deepest_nested_depth
+          pathnames.map(&:length).max
+        end
 
         def sorted_parent_ids
           parent_ids.sort

--- a/lib/samvera/nesting_indexer/relationship_reindexer.rb
+++ b/lib/samvera/nesting_indexer/relationship_reindexer.rb
@@ -44,7 +44,7 @@ module Samvera
 
       private
 
-      attr_reader :queue, :configuration, :visited_ids
+      attr_reader :queue, :configuration
 
       def process_each_document
         processing_document = dequeue

--- a/lib/samvera/nesting_indexer/relationship_reindexer.rb
+++ b/lib/samvera/nesting_indexer/relationship_reindexer.rb
@@ -109,7 +109,7 @@ module Samvera
         logger.debug("Ending #{message_suffix}")
       end
 
-      # A small object that helps encapsulate the logic of building the hash of information regarding
+      # A small object that helps encapsulate the logic for building the hash of information regarding
       # the initialization of an Samvera::NestingIndexer::Documents::IndexDocument
       #
       # @see Samvera::NestingIndexer::Documents::IndexDocument for details on pathnames, ancestors, and parent_ids.
@@ -121,15 +121,15 @@ module Samvera
           @ancestors = Set.new
           @adapter = adapter
           compile!
+          @inner_document = Documents::IndexDocument.new(id: @preservation_document.id, parent_ids: @parent_ids, pathnames: @pathnames, ancestors: @ancestors)
         end
 
-        def to_hash
-          { id: @preservation_document.id, parent_ids: @parent_ids.to_a, pathnames: @pathnames.to_a, ancestors: @ancestors.to_a }
-        end
+        extend Forwardable
+        def_delegator :inner_document, :to_hash
 
         private
 
-        attr_reader :adapter
+        attr_reader :adapter, :inner_document
 
         def compile!
           @preservation_document.parent_ids.each do |parent_id|

--- a/spec/lib/samvera/nesting_indexer/adapters/abstract_adapter_spec.rb
+++ b/spec/lib/samvera/nesting_indexer/adapters/abstract_adapter_spec.rb
@@ -48,6 +48,12 @@ module Samvera
             expect { subject }.to raise_error(NotImplementedError)
           end
         end
+        describe '.write_nesting_document_to_index_layer' do
+          subject { described_class.write_nesting_document_to_index_layer(nesting_document: 1) }
+          it 'requires implementation (see documentation)' do
+            expect { subject }.to raise_error(NotImplementedError)
+          end
+        end
       end
     end
   end

--- a/spec/lib/samvera/nesting_indexer/adapters/abstract_adapter_spec.rb
+++ b/spec/lib/samvera/nesting_indexer/adapters/abstract_adapter_spec.rb
@@ -9,48 +9,49 @@ module Samvera
         it_behaves_like 'a Samvera::NestingIndexer::Adapter'
         describe '.find_preservation_document_by(id:)' do
           subject { described_class.find_preservation_document_by(id: 1) }
-          it 'requires implementation (see documentation)' do
+          it 'is defined but requires implementation in classes that extend this class (see documentation)' do
             expect { subject }.to raise_error(NotImplementedError)
           end
         end
 
         describe '.find_index_document_by' do
           subject { described_class.find_index_document_by(id: 1) }
-          it 'requires implementation (see documentation)' do
+          it 'is defined but requires implementation in classes that extend this class (see documentation)' do
             expect { subject }.to raise_error(NotImplementedError)
           end
         end
 
         describe '.each_perservation_document_id_and_parent_ids' do
           subject { described_class.each_perservation_document_id_and_parent_ids }
-          it 'requires implementation (see documentation)' do
+          it 'is defined but requires implementation in classes that extend this class (see documentation)' do
             expect { subject }.to raise_error(NotImplementedError)
           end
         end
 
         describe '.find_preservation_parent_ids_for(id:)' do
           subject { described_class.find_preservation_parent_ids_for(id: 1) }
-          it 'requires implementation (see documentation)' do
+          it 'is defined but requires implementation in classes that extend this class (see documentation)' do
             expect { subject }.to raise_error(NotImplementedError)
           end
         end
 
         describe '.each_child_document_of' do
           subject { described_class.each_child_document_of(document: double) }
-          it 'requires implementation (see documentation)' do
+          it 'is defined but requires implementation in classes that extend this class (see documentation)' do
             expect { subject }.to raise_error(NotImplementedError)
           end
         end
 
         describe '.write_document_attributes_to_index_layer' do
           subject { described_class.write_document_attributes_to_index_layer(id: 1, parent_ids: 2, ancestors: 3, pathnames: 4, deepest_nested_depth: 5) }
-          it 'requires implementation (see documentation)' do
+          it 'is defined but requires implementation in classes that extend this class (see documentation)' do
             expect { subject }.to raise_error(NotImplementedError)
           end
         end
+
         describe '.write_nesting_document_to_index_layer' do
           subject { described_class.write_nesting_document_to_index_layer(nesting_document: 1) }
-          it 'requires implementation (see documentation)' do
+          it 'is defined but requires implementation in classes that extend this class (see documentation)' do
             expect { subject }.to raise_error(NotImplementedError)
           end
         end

--- a/spec/lib/samvera/nesting_indexer/adapters/abstract_adapter_spec.rb
+++ b/spec/lib/samvera/nesting_indexer/adapters/abstract_adapter_spec.rb
@@ -43,7 +43,7 @@ module Samvera
         end
 
         describe '.write_document_attributes_to_index_layer' do
-          subject { described_class.write_document_attributes_to_index_layer(id: 1, parent_ids: 2, ancestors: 3, pathnames: 4) }
+          subject { described_class.write_document_attributes_to_index_layer(id: 1, parent_ids: 2, ancestors: 3, pathnames: 4, deepest_nested_depth: 5) }
           it 'requires implementation (see documentation)' do
             expect { subject }.to raise_error(NotImplementedError)
           end

--- a/spec/lib/samvera/nesting_indexer/adapters/in_memory_adapter_spec.rb
+++ b/spec/lib/samvera/nesting_indexer/adapters/in_memory_adapter_spec.rb
@@ -7,6 +7,15 @@ module Samvera
     module Adapters
       RSpec.describe InMemoryAdapter do
         it_behaves_like 'a Samvera::NestingIndexer::Adapter'
+
+        # In place to appease code coverage
+        describe '#write_document_attributes_to_index_layer' do
+          it 'is a deprecated method' do
+            expect do
+              described_class.write_document_attributes_to_index_layer(id: 'a', pathnames: ['a'], ancestors: [], deepest_nested_depth: 1, parent_ids: [])
+            end.not_to raise_error
+          end
+        end
       end
     end
   end

--- a/spec/lib/samvera/nesting_indexer/documents_spec.rb
+++ b/spec/lib/samvera/nesting_indexer/documents_spec.rb
@@ -9,6 +9,11 @@ module Samvera
           subject { index_document.deepest_nested_depth }
           it { is_expected.to be_a(Integer) }
         end
+
+        describe '#to_hash' do
+          subject { index_document.to_hash }
+          it { is_expected.to be_a(Hash) }
+        end
       end
     end
   end

--- a/spec/lib/samvera/nesting_indexer/documents_spec.rb
+++ b/spec/lib/samvera/nesting_indexer/documents_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+module Samvera
+  module NestingIndexer
+    module Documents
+      RSpec.describe IndexDocument do
+        let(:index_document) { described_class.new(id: 'a', parent_ids: 'b', pathnames: ['b/a'], ancestors: ['b']) }
+        describe '#deepest_nested_depth' do
+          subject { index_document.deepest_nested_depth }
+          it { is_expected.to be_a(Integer) }
+        end
+      end
+    end
+  end
+end

--- a/spec/support/feature_spec_support_methods.rb
+++ b/spec/support/feature_spec_support_methods.rb
@@ -14,21 +14,21 @@ module Support
     end
 
     def build_index_document(id, graph)
-      document = Samvera::NestingIndexer::Documents::IndexDocument.new(
+      nesting_document = Samvera::NestingIndexer::Documents::IndexDocument.new(
         id: id,
         parent_ids: graph.fetch(:parent_ids).fetch(id),
         ancestors: graph.fetch(:ancestors, {})[id],
         pathnames: graph.fetch(:pathnames, {})[id]
       )
-      Samvera::NestingIndexer.adapter.write_document_attributes_to_index_layer(document.to_hash)
+      Samvera::NestingIndexer.adapter.write_nesting_document_to_index_layer(nesting_document: nesting_document)
     end
 
     # Logic that mirrors the behavior of updating an ActiveFedora object.
     def write_document_to_persistence_layers(preservation_document_attributes_to_update)
       Samvera::NestingIndexer.adapter.write_document_attributes_to_preservation_layer(preservation_document_attributes_to_update)
       attributes = { pathnames: [], ancestors: [] }.merge(preservation_document_attributes_to_update)
-      index_document = Samvera::NestingIndexer::Documents::IndexDocument.new(**attributes)
-      Samvera::NestingIndexer.adapter.write_document_attributes_to_index_layer(index_document.to_hash)
+      nesting_document = Samvera::NestingIndexer::Documents::IndexDocument.new(**attributes)
+      Samvera::NestingIndexer.adapter.write_nesting_document_to_index_layer(nesting_document: nesting_document)
     end
 
     def verify_graph_versus_storage(ending_graph)

--- a/spec/support/feature_spec_support_methods.rb
+++ b/spec/support/feature_spec_support_methods.rb
@@ -14,19 +14,21 @@ module Support
     end
 
     def build_index_document(id, graph)
-      Samvera::NestingIndexer.adapter.write_document_attributes_to_index_layer(
+      document = Samvera::NestingIndexer::Documents::IndexDocument.new(
         id: id,
         parent_ids: graph.fetch(:parent_ids).fetch(id),
         ancestors: graph.fetch(:ancestors, {})[id],
         pathnames: graph.fetch(:pathnames, {})[id]
       )
+      Samvera::NestingIndexer.adapter.write_document_attributes_to_index_layer(document.to_hash)
     end
 
     # Logic that mirrors the behavior of updating an ActiveFedora object.
     def write_document_to_persistence_layers(preservation_document_attributes_to_update)
       Samvera::NestingIndexer.adapter.write_document_attributes_to_preservation_layer(preservation_document_attributes_to_update)
       attributes = { pathnames: [], ancestors: [] }.merge(preservation_document_attributes_to_update)
-      Samvera::NestingIndexer.adapter.write_document_attributes_to_index_layer(**attributes)
+      index_document = Samvera::NestingIndexer::Documents::IndexDocument.new(**attributes)
+      Samvera::NestingIndexer.adapter.write_document_attributes_to_index_layer(index_document.to_hash)
     end
 
     def verify_graph_versus_storage(ending_graph)


### PR DESCRIPTION
## Adding #deepest_nested_depth for indexing doc

9942634cf4aaa49a5c8c7aacb2f23116af46c9f6

In working through Samvera nesting indexing, it became clear that it
would be helpful to know the current depth of an indexed document. This
is something easily calculated when the
`Samvera::NestingIndexer::Document::IndexDocument` is being created.

As part of this change, I pushed code to use the already existing
`Samvera::NestingIndexer::Document::IndexDocument`; which removes some
duplication of knowledge and hints at future steps to remove
duplication.

A future change would be to shift from primitive parameters when writing
to the index layer to a
`Samvera::NestingIndexer::Document::IndexDocument`. In this way future
changes to the API would be a bit less brittle (e.g. wouldn't have to
add new keywords to the parameter list).

## Replacing multi-parameters with parameter object

bed0f8362e20629773f55b60dbaccde78e415c48

It is good practice to question any method with more than 3 parameters.
I believe this is especially important when the method defines an
interface to external implementations.

This commit preserves the existing method, though it no longer uses
that method. The gem now uses the new method.

Implementors will need to replace their existing
`.write_document_attributes_to_index_layer` method with a
slight modification `.write_nesting_document_to_index_layer`.

This is a breaking upstream change. However, I believe there are few
implementations of this, and as such is something we can change if we
coordinate updates to upstream changes:

* https://github.com/samvera/hyrax/blob/collections-sprint/app/services/hyrax/adapters/nesting_index_adapter.rb#L61-L81

## Removing unused method

c99e6f2410dcea1da63b1a38a621e62881d808e1

The method was added in SHA 9aac7cfcdc29586a249842ebdc929e6172539689
but the parameter and possible usage was removed in SHA
f896cdfab7750b2941da8ffb8f7c7d3cf8a1a69a

This was detected using the [debride][debride] gem

[debride]:https://github.com/seattlerb/debride

## Expanding spec description to provide guidance

2802d67429ab9344e172224fb62688a669180f17

From PR Conversation samvera-labs/samvera-nesting_indexer#6

@elrayle

> Would it be better to write this as a pending test? That way it would
> show up in the rspec log as pending giving a reminder to come back to
> it.

@jeremyf

> The methods are part of an abstract adapter; The abstract adapter
> methods define method signature but not implementation. The class that
> extends this adapter would then need to implement.
