### PR TITLE
Defining public interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The Samvera::NestingIndexer gem generates the graph related attributes related t
 * [Examples](#examples)
 * [Adapters](#adapters)
 * [Considerations](#considerations)
+* [Public API for Semantic Versioning](#public_api_for_semantic_versioning)
 
 ## Background
 
@@ -144,6 +145,20 @@ In implementations, you'll likely want to write queries that answer:
 
 * Find the valid IDs that I can nest within?
 * Find the valid IDs in which I can nest within and am not already nested within?
+
+## Public API for Semantic Versioning
+
+Any method with `@api public` documentation is part of the semantically versioned API. This means you can assume:
+
+* the method will exist with the same effective signature (perhaps with changes to defaults)
+* the method can be called by upstream consumers
+* deprecations will be announced prior to major version upgrades
+
+Any module or class with `@api public` documentation is part of the semantically versioned API. This means you can assume:
+
+* the module or class can be accessed upstream
+* all public methods are assumed to be `@api public` unless otherwise stated
+* deprecations will be announced prior to major version upgrades
 
 ## TODO
 

--- a/lib/samvera/nesting_indexer.rb
+++ b/lib/samvera/nesting_indexer.rb
@@ -6,7 +6,10 @@ require 'samvera/nesting_indexer/documents'
 require 'samvera/nesting_indexer/railtie' if defined?(Rails)
 
 module Samvera
-  # Responsible for indexing an object and its related child objects.
+  # @api public
+  #
+  # A container module responsible for exposing public API methods for nested indexing and the
+  # underlying configuration to perform that indexing.
   module NestingIndexer
     # @api public
     # Responsible for reindexing the associated document for the given :id and the descendants of that :id.
@@ -85,6 +88,10 @@ module Samvera
       return false unless @configuration_block.respond_to?(:call)
       @configuration_block.call(configuration)
       @configuration_block = nil
+    end
+
+    def self.semantic_version_messages
+      SemverAssistant.messages
     end
   end
 end

--- a/lib/samvera/nesting_indexer/adapters/in_memory_adapter.rb
+++ b/lib/samvera/nesting_indexer/adapters/in_memory_adapter.rb
@@ -9,11 +9,13 @@ module Samvera
       # Defines the interface for interacting with the InMemory layer. It is a reference
       # implementation that is used throughout tests.
       module InMemoryAdapter
+        SemverAssistant.removing_from_public_api(context: self, as_of: '2.0.0')
         extend AbstractAdapter
         # @api public
         # @param id [String]
         # @return Samvera::NestingIndexer::Document::PreservationDocument
         def self.find_preservation_document_by(id:)
+          SemverAssistant.removing_from_public_api(context: "#{self.class}##{__method__}", as_of: '2.0.0')
           Preservation.find(id)
         end
 
@@ -21,6 +23,7 @@ module Samvera
         # @param id [String]
         # @return [Samvera::NestingIndexer::Documents::IndexDocument]
         def self.find_index_document_by(id:)
+          SemverAssistant.removing_from_public_api(context: "#{self.class}##{__method__}", as_of: '2.0.0')
           Index.find(id)
         end
 
@@ -28,6 +31,7 @@ module Samvera
         # @yieldparam id [String] The `id` of the preservation document
         # @yieldparam parent_ids [String] The ids of the parent objects of this presevation document
         def self.each_perservation_document_id_and_parent_ids(&block)
+          SemverAssistant.removing_from_public_api(context: "#{self.class}##{__method__}", as_of: '2.0.0')
           Preservation.find_each do |document|
             block.call(document.id, document.parent_ids)
           end
@@ -41,6 +45,7 @@ module Samvera
         # @param document [Samvera::NestingIndexer::Documents::IndexDocument]
         # @yield [Samvera::NestingIndexer::Documents::IndexDocument]
         def self.each_child_document_of(document:, &block)
+          SemverAssistant.removing_from_public_api(context: "#{self.class}##{__method__}", as_of: '2.0.0')
           Index.each_child_document_of(document: document, &block)
         end
 
@@ -50,6 +55,7 @@ module Samvera
         # @param attributes [Hash]
         # @return [Samvera::NestingIndexer::Documents::PreservationDocument]
         def self.write_document_attributes_to_preservation_layer(attributes)
+          SemverAssistant.removing_from_public_api(context: "#{self.class}##{__method__}", as_of: '2.0.0')
           Preservation.write_document(attributes)
         end
 
@@ -62,6 +68,7 @@ module Samvera
         # @param deepest_nested_depth [Integer]
         # @return [Hash] - the attributes written to the indexing layer
         def self.write_document_attributes_to_index_layer(id:, parent_ids:, ancestors:, pathnames:, deepest_nested_depth:)
+          SemverAssistant.removing_from_public_api(context: "#{self.class}##{__method__}", as_of: '2.0.0')
           Index.write_document(id: id, parent_ids: parent_ids, ancestors: ancestors, pathnames: pathnames, deepest_nested_depth: deepest_nested_depth)
         end
 
@@ -69,6 +76,7 @@ module Samvera
         # @see README.md
         # @param nesting_document [Samvera::NestingIndexer::Documents::IndexDocument]
         def self.write_nesting_document_to_index_layer(nesting_document:)
+          SemverAssistant.removing_from_public_api(context: "#{self.class}##{__method__}", as_of: '2.0.0')
           Index.write_to_storage(nesting_document)
         end
 

--- a/lib/samvera/nesting_indexer/configuration.rb
+++ b/lib/samvera/nesting_indexer/configuration.rb
@@ -3,7 +3,6 @@ require 'samvera/nesting_indexer/exceptions'
 require 'logger'
 
 module Samvera
-  # :nodoc:
   module NestingIndexer
     # @api public
     # Responsible for the configuration of the Samvera::NestingIndexer
@@ -81,6 +80,6 @@ module Samvera
         end
       end
     end
-    private_constant :Configuration
   end
 end
+Samvera::NestingIndexer.private_constant :Configuration

--- a/lib/samvera/nesting_indexer/documents.rb
+++ b/lib/samvera/nesting_indexer/documents.rb
@@ -1,7 +1,9 @@
 require 'dry-equalizer'
+require 'samvera/nesting_indexer/semver_assistant'
 
 module Samvera
   module NestingIndexer
+    # @api public
     module Documents
       ANCESTOR_AND_PATHNAME_DELIMITER = '/'.freeze
 
@@ -14,10 +16,12 @@ module Samvera
           @id = keywords.fetch(:id).to_s
           @parent_ids = Array(keywords.fetch(:parent_ids))
         end
+        SemverAssistant.removing_from_public_api(context: self, as_of: '2.0.0')
 
         # @api public
         # @return String The Fedora object's PID
         attr_reader :id
+        SemverAssistant.removing_from_public_api(context: "#{self}#id", as_of: '2.0.0')
 
         # @api public
         #
@@ -26,6 +30,7 @@ module Samvera
         # This does not include grandparents, great-grandparents, etc.
         # @return Array<String>
         attr_reader :parent_ids
+        SemverAssistant.removing_from_public_api(context: "#{self}#parent_id", as_of: '2.0.0')
       end
 
       # @api public
@@ -100,14 +105,17 @@ module Samvera
         end
 
         def sorted_parent_ids
+          SemverAssistant.removing_from_public_api(context: "#{self.class}##{__method__}", as_of: '2.0.0')
           parent_ids.sort
         end
 
         def sorted_pathnames
+          SemverAssistant.removing_from_public_api(context: "#{self.class}##{__method__}", as_of: '2.0.0')
           pathnames.sort
         end
 
         def sorted_ancestors
+          SemverAssistant.removing_from_public_api(context: "#{self.class}##{__method__}", as_of: '2.0.0')
           ancestors.sort
         end
       end

--- a/lib/samvera/nesting_indexer/relationship_reindexer.rb
+++ b/lib/samvera/nesting_indexer/relationship_reindexer.rb
@@ -3,7 +3,6 @@ require 'forwardable'
 require 'set'
 
 module Samvera
-  # Establishing namespace
   module NestingIndexer
     # Responsible for reindexing the document associated with the given PID and its descendant documents
     # @note There is cycle detection via the Samvera::NestingIndexer::Configuration#maximum_nesting_depth counter
@@ -153,6 +152,6 @@ module Samvera
       end
       private_constant :ParentAndPathAndAncestorsBuilder
     end
-    private_constant :RelationshipReindexer
   end
 end
+Samvera::NestingIndexer.private_constant :RelationshipReindexer

--- a/lib/samvera/nesting_indexer/repository_reindexer.rb
+++ b/lib/samvera/nesting_indexer/repository_reindexer.rb
@@ -1,7 +1,6 @@
 require 'samvera/nesting_indexer/exceptions'
 require 'forwardable'
 module Samvera
-  # Establishing namespace
   module NestingIndexer
     # Responsible for reindexing the entire repository
     # @api private
@@ -70,6 +69,6 @@ module Samvera
         raise Exceptions::ReindexingError.new(id, e)
       end
     end
-    private_constant :RepositoryReindexer
   end
 end
+Samvera::NestingIndexer.private_constant :RepositoryReindexer

--- a/lib/samvera/nesting_indexer/semver_assistant.rb
+++ b/lib/samvera/nesting_indexer/semver_assistant.rb
@@ -14,6 +14,6 @@ module Samvera
         ActiveSupport::Deprecation.warn(message, caller[1..-1]) if defined?(ActiveSupport::Deprecation) && !ENV.key?('SKIP_ACTIVE_SUPPORT_DEPRECATION')
       end
     end
-    private_constant :SemverAssistant
   end
 end
+Samvera::NestingIndexer.private_constant :SemverAssistant

--- a/lib/samvera/nesting_indexer/semver_assistant.rb
+++ b/lib/samvera/nesting_indexer/semver_assistant.rb
@@ -1,0 +1,19 @@
+require 'set'
+module Samvera
+  module NestingIndexer
+    # @api private
+    # A service object responsible for coordinating declarations of interface changes
+    module SemverAssistant
+      def self.messages
+        @messages ||= Set.new
+      end
+
+      def self.removing_from_public_api(context:, as_of:)
+        message = "As of version #{as_of}, #{context} will be removed from the public API"
+        messages << message
+        ActiveSupport::Deprecation.warn(message, caller[1..-1]) if defined?(ActiveSupport::Deprecation) && !ENV.key?('SKIP_ACTIVE_SUPPORT_DEPRECATION')
+      end
+    end
+    private_constant :SemverAssistant
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,3 +7,16 @@ require 'rspec/its'
 Samvera::NestingIndexer.configure do |config|
   config.logger = Logger.new('/dev/null') unless ENV['VERBOSE'] # Remove all the chatter!
 end
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    ENV['SKIP_ACTIVE_SUPPORT_DEPRECATION'] = '1'
+  end
+  config.after(:suite) do
+    STDOUT.puts "\n" + "-" * 80 + "\nSemantic Version Messages:\n" + "-" * 80 + "\n"
+    Samvera::NestingIndexer.semantic_version_messages.each do |message|
+      STDOUT.puts message
+    end
+    STDOUT.puts "-" * 80 + "\n"
+  end
+end


### PR DESCRIPTION
## Tightening up public interface definition

ed7972f7c0322d9ce33de7d84c4b39f2751e0195

This includes an explicit definition of what is in the public API, as
well as what is slated to be removed from the public API.

My goal, in this effort, is to begin to explore what semblance of
automation we might be able to perform. I think it is beyond feasible
at this point, but I want to think about how we, the community, are
modeling the declaration of a public interface.

## Adjusting

e9934d227843d6c6576a3affddf2c49503a4e169

In reviewing the yard documentation, I was expecting the
`Samvera::NestingIndexer` documentation to be the comments from
`./lib/samvera/nesting_indexer.rb`. However the actual documentation was
"Establishing Namespace".

Upon further inspection of
[Rubocop's documentation][rubocop_documentation], I found the following:

> This cop checks for missing top-level documentation of classes and
> modules. Classes with no body are exempt from the check and so are
> namespace modules - modules that have nothing in their bodies except
> classes or other other modules.

These changes address the documentation of Rubocop. Now, when I run
yard I get the expected comments.

[rubocop_documentation]:http://www.rubydoc.info/github/bbatsov/rubocop/Rubocop/Cop/Style/Documentation
