### PR TITLE
Tidying up gem for promotion

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,36 @@
+The Samvera community is dedicated to providing a welcoming and
+positive experience for all its members, whether they are at a formal
+gathering, in a social setting, or taking part in activities online.
+The Samvera community welcomes participation from people all over the
+world and these members bring with them a wide variety of
+professional, personal and social backgrounds; whatever these may be,
+we treat colleagues with dignity and respect.
+
+Community members communicate primarily in English, though for many of
+them this is not their native language. We therefore strive to express
+ourselves simply and clearly remembering that unnecessary use of
+jargon and slang will be a barrier to understanding for many of our
+colleagues.  We are sensitive to the fact that the international
+nature of the community means that we span many different social norms
+around language and behaviour and we strive to conduct ourselves,
+online and in person, in ways that are unlikely to cause offence.
+
+Samvera conversations are often information-rich and intended to
+generate discussion and debate.  We discuss ideas from a standpoint of
+mutual respect and reasoned argument.
+
+Community members work together to promote a respectful and safe
+community. In the event that someone’s conduct is causing offence or
+distress, Samvera has a detailed
+[Anti-Harassment Policy and Protocol](https://wiki.duraspace.org/display/hydra/Anti-Harassment+Policy)
+which can be applied to address the problem. The first step in dealing
+with any serious misconduct is to contact a local meeting organizer,
+the
+[Samvera community helpers](https://wiki.duraspace.org/display/hydra/Hydra+Community+Helpers)
+([email](mailto:helpers@projecthydra.org)), a community member you
+trust, or the
+[Samvera Steering Group](https://wiki.duraspace.org/display/hydra/Samvera+Steering+Group+membership)
+immediately; at Samvera events, these people can be identified by
+distinctive name badges. The
+[Policy and Protocol](https://wiki.duraspace.org/display/hydra/Anti-Harassment+Policy)
+should be consulted for fuller details.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,169 @@
+# How to Contribute
+
+We want your help to make Samvera great. There are a few guidelines
+that we need contributors to follow so that we can have a chance of
+keeping on top of things.
+
+## Code of Conduct
+
+The Samvera Community is dedicated to providing a welcoming and positive
+experience for all its members, whether they are at a formal gathering, in
+a social setting, or taking part in activities online. Please see our
+[Code of Conduct](CODE_OF_CONDUCT.md) for more information.
+
+## Samvera Community Intellectual Property Licensing and Ownership
+
+All code contributors must have an Individual Contributor License Agreement
+(iCLA) on file with the Samvera Steering Group. If the contributor works for
+an institution, the institution must have a Corporate Contributor License
+Agreement (cCLA) on file.
+
+https://wiki.duraspace.org/display/hydra/Hydra+Project+Intellectual+Property+Licensing+and+Ownership
+
+You should also add yourself to the `CONTRIBUTORS.md` file in the root of the project.
+
+## Contribution Tasks
+
+* Reporting Issues
+* Making Changes
+* Documenting Code
+* Committing Changes
+* Submitting Changes
+* Reviewing and Merging Changes
+
+### Reporting Issues
+
+* Make sure you have a [GitHub account](https://github.com/signup/free)
+* Submit a [Github issue](./issues) by:
+  * Clearly describing the issue
+    * Provide a descriptive summary
+    * Explain the expected behavior
+    * Explain the actual behavior
+    * Provide steps to reproduce the actual behavior
+
+### Making Changes
+
+* Fork the repository on GitHub
+* Create a topic branch from where you want to base your work.
+  * This is usually the master branch.
+  * To quickly create a topic branch based on master; `git branch fix/master/my_contribution master`
+  * Then checkout the new branch with `git checkout fix/master/my_contribution`.
+  * Please avoid working directly on the `master` branch.
+  * You may find the [hub suite of commands](https://github.com/defunkt/hub) helpful
+* Make sure you have added sufficient tests and documentation for your changes.
+  * Test functionality with RSpec; Test features / UI with Capybara.
+* Run _all_ the tests to assure nothing else was accidentally broken.
+
+### Documenting Code
+
+* All new public methods, modules, and classes should include inline documentation in [YARD](http://yardoc.org/).
+  * Documentation should seek to answer the question "why does this code exist?"
+* Document private / protected methods as desired.
+* If you are working in a file with no prior documentation, do try to document as you gain understanding of the code.
+  * If you don't know exactly what a bit of code does, it is extra likely that it needs to be documented. Take a stab at it and ask for feedback in your pull request. You can use the 'blame' button on GitHub to identify the original developer of the code and @mention them in your comment.
+  * This work greatly increases the usability of the code base and supports the on-ramping of new committers.
+  * We will all be understanding of one another's time constraints in this area.
+* YARD examples:
+  * [Hydra::Works::RemoveGenericFile](https://github.com/projecthydra-labs/hydra-works/blob/master/lib/hydra/works/services/generic_work/remove_generic_file.rb)
+  * [ActiveTriples::LocalName::Minter](https://github.com/ActiveTriples/active_triples-local_name/blob/master/lib/active_triples/local_name/minter.rb)
+* [Getting started with YARD](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md)
+
+### Committing changes
+
+* Make commits of logical units.
+  * Your commit should include a high level description of your work in HISTORY.textile
+* Check for unnecessary whitespace with `git diff --check` before committing.
+* Make sure your commit messages are [well formed](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+* If you created an issue, you can close it by including "Closes #issue" in your commit message. See [Github's blog post for more details](https://github.com/blog/1386-closing-issues-via-commit-messages)
+
+```
+    Present tense short summary (50 characters or less)
+
+    More detailed description, if necessary. It should be wrapped to 72
+    characters. Try to be as descriptive as you can, even if you think that
+    the commit content is obvious, it may not be obvious to others. You
+    should add such description also if it's already present in bug tracker,
+    it should not be necessary to visit a webpage to check the history.
+
+    Include Closes #<issue-number> when relavent.
+
+    Description can have multiple paragraphs and you can use code examples
+    inside, just indent it with 4 spaces:
+
+        class PostsController
+          def index
+            respond_to do |wants|
+              wants.html { render 'index' }
+            end
+          end
+        end
+
+    You can also add bullet points:
+
+    - you can use dashes or asterisks
+
+    - also, try to indent next line of a point for readability, if it's too
+      long to fit in 72 characters
+```
+
+* Make sure you have added the necessary tests for your changes.
+* Run _all_ the tests to assure nothing else was accidentally broken.
+* When you are ready to submit a pull request
+
+### Submitting Changes
+
+[Detailed Walkthrough of One Pull Request per Commit](http://ndlib.github.io/practices/one-commit-per-pull-request/)
+
+* Read the article ["Using Pull Requests"](https://help.github.com/articles/using-pull-requests) on GitHub.
+* Make sure your branch is up to date with its parent branch (i.e. master)
+  * `git checkout master`
+  * `git pull --rebase`
+  * `git checkout <your-branch>`
+  * `git rebase master`
+  * It is a good idea to run your tests again.
+* If you've made more than one commit take a moment to consider whether squashing commits together would help improve their logical grouping.
+  * [Detailed Walkthrough of One Pull Request per Commit](http://ndlib.github.io/practices/one-commit-per-pull-request/)
+  * `git rebase --interactive master` ([See Github help](https://help.github.com/articles/interactive-rebase))
+  * Squashing your branch's changes into one commit is "good form" and helps the person merging your request to see everything that is going on.
+* Push your changes to a topic branch in your fork of the repository.
+* Submit a pull request from your fork to the project.
+
+### Reviewing and Merging Changes
+
+We adopted [Github's Pull Request Review](https://help.github.com/articles/about-pull-request-reviews/) for our repositories.
+Common checks that may occur in our repositories:
+
+1. Travis CI - where our automated tests are running
+2. Hound CI - where we check for style violations
+3. Approval Required - Github enforces at least one person approve a pull request. Also, all reviewers that have chimed in must approve.
+4. CodeClimate - is our code remaining healthy (at least according to static code analysis)
+
+If one or more of the required checks failed (or are incomplete), the code should not be merged (and the UI will not allow it). If all of the checks have passed, then anyone on the project (including the pull request submitter) may merge the code.
+
+*Example: Carolyn submits a pull request, Justin reviews the pull request and approves. However, Justin is still waiting on other checks (Travis CI is usually the culprit), so he does not merge the pull request. Eventually, all of the checks pass. At this point, Carolyn or anyone else may merge the pull request.*
+
+#### Things to Consider When Reviewing
+
+First, the person contributing the code is putting themselves out there. Be mindful of what you say in a review.
+
+* Ask clarifying questions
+* State your understanding and expectations
+* Provide example code or alternate solutions, and explain why
+
+This is your chance for a mentoring moment of another developer. Take time to give an honest and thorough review of what has changed. Things to consider:
+
+  * Does the commit message explain what is going on?
+  * Does the code changes have tests? _Not all changes need new tests, some changes are refactorings_
+  * Do new or changed methods, modules, and classes have documentation?
+  * Does the commit contain more than it should? Are two separate concerns being addressed in one commit?
+  * Does the description of the new/changed specs match your understanding of what the spec is doing?
+  * Did the Travis tests complete successfully?
+
+If you are uncertain, bring other contributors into the conversation by assigning them as a reviewer.
+
+# Additional Resources
+
+* [General GitHub documentation](http://help.github.com/)
+* [GitHub pull request documentation](http://help.github.com/send-pull-requests/)
+* [Pro Git](http://git-scm.com/book) is both a free and excellent book about Git.
+* [A Git Config for Contributing](http://ndlib.github.io/practices/my-typical-per-project-git-config/)

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+### Descriptive summary
+
+Include what version of Hyrax relates to this issue (7.x, 6.x, HEAD, etc.) if appropriate, and any relevant tracebacks if you're reporting a bug.
+
+### Rationale
+
+Provide the rationale or user story that describes "why" this issue should be addressed. Especially if this is a new feature or significant change to the existing implementation.
+
+### Expected behavior
+
+### Actual behavior
+
+### Steps to reproduce the behavior
+
+1. Do this
+1. Then do this...
+
+### Related work
+
+Link to related tickets or prior related work here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+Present tense short summary (50 characters or less)
+
+Fixes #issuenumber ; refs #issuenumber
+
+More detailed description, if necessary. Try to be as descriptive as
+you can: even if you think that the PR content is obvious, it may not
+be obvious to others. Include tracebacks if helpful, and be sure to
+call out any bits of the PR that may be work-in-progress.
+
+Description can have multiple paragraphs and you can use code examples
+inside:
+
+``` ruby
+class PostsController
+  def index
+    respond_with Post.limit(10)
+  end
+end
+```
+
+Changes proposed in this pull request:
+*
+*
+*
+
+@samvera/hyrax-code-reviewers

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,3 @@
+If you would like to report an issue with Hyrax, first do search [the list of issues](https://github.com/samvera/samvera-nesting_indexer/issues/) to see if someone else has already reported it, and then feel free to [create a new issue](https://github.com/samvera/samvera-nesting_indexer/issues/new).
+
+If you have questions or need help, please email [the Samvera community tech list](mailto:samvera-tech@googlegroups.com) or stop by the #dev channel in [the Samvera community Slack team](https://wiki.duraspace.org/pages/viewpage.action?pageId=87460391#Getintouch!-Slack).

--- a/LICENSE
+++ b/LICENSE
@@ -1,14 +1,203 @@
-##########################################################################
-# Copyright 2014-2015 University of Notre Dame
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2014-2017 University of Notre Dame
+   Additional copyright may be held by others, as reflected in the commit log
+
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/samvera-nesting_indexer.gemspec
+++ b/samvera-nesting_indexer.gemspec
@@ -20,20 +20,19 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '~>2.0'
 
   spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rspec-its"
+  spec.add_development_dependency "byebug"
+  spec.add_development_dependency "codeclimate-test-reporter"
   spec.add_development_dependency "guard-rspec"
   spec.add_development_dependency "guard-rubocop"
-  spec.add_development_dependency "terminal-notifier-guard"
-  spec.add_development_dependency "terminal-notifier"
+  spec.add_development_dependency "json"
+  spec.add_development_dependency "listen", '~> 3.0.8'
+  spec.add_development_dependency "railties"
+  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec-its"
+  spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "codeclimate-test-reporter"
-  spec.add_development_dependency "json"
-  spec.add_development_dependency "byebug"
-  spec.add_development_dependency "railties"
-  # As a secondary dependency, listen is preventing bundling
-  spec.add_development_dependency "listen", '~> 3.0.8'
+  spec.add_development_dependency "terminal-notifier-guard"
+  spec.add_development_dependency "terminal-notifier"
   spec.add_dependency "dry-equalizer"
 end


### PR DESCRIPTION
## Alphabetizing dependency declarations

298b4c9f4565b9682f624c74f0a13a33146bf980

Instead of an adhoc order, leverage an alphabetized order.

Preparing for [promotion][promotion] to https://github.com/samvera from
https://github.com/samvera-labs.

[promotion]:http://samvera-labs.github.io/promotion.html

## Updating license to include full Apache2 text

0ec9921d863d1e9afeba2874fcf93f0250a27a9f

Preparing for [promotion][promotion] to https://github.com/samvera from
https://github.com/samvera-labs.

[promotion]:http://samvera-labs.github.io/promotion.html

## Adding .github and related files

ca46cebce1b1896e31a655cb389948d02c448a64

These were copied from samvera/hyrax and amended to reflect minor
changes.

Preparing for [promotion][promotion] to https://github.com/samvera from
https://github.com/samvera-labs.

[promotion]:http://samvera-labs.github.io/promotion.html
