### PR TITLE
Fixing bug in #deepest_nested_depth calculation

### DIFF
--- a/lib/samvera/nesting_indexer/documents.rb
+++ b/lib/samvera/nesting_indexer/documents.rb
@@ -101,7 +101,9 @@ module Samvera
         #
         # @return Integer
         def deepest_nested_depth
-          pathnames.map(&:length).max
+          pathnames.map do |pathname|
+            pathname.split(ANCESTOR_AND_PATHNAME_DELIMITER).count
+          end.max
         end
 
         def sorted_parent_ids

--- a/spec/lib/samvera/nesting_indexer/documents_spec.rb
+++ b/spec/lib/samvera/nesting_indexer/documents_spec.rb
@@ -8,6 +8,10 @@ module Samvera
         describe '#deepest_nested_depth' do
           subject { index_document.deepest_nested_depth }
           it { is_expected.to be_a(Integer) }
+
+          it 'is determined by longest pathname' do
+            expect(subject).to eq(2)
+          end
         end
 
         describe '#to_hash' do


### PR DESCRIPTION
## Fixing bug in #deepest_nested_depth calculation

aafcaf0367bf81b401859e89e1c54f723b92c0f9

Prior to this fix, I was calculating the longest string in pathnames. I
instead needed to calculate the number of nodes in those pathnames
