### PR TITLE
Memoize initial_index_document and add :extent parameter

### DIFF
--- a/lib/generators/samvera/nesting_indexer/install_generator.rb
+++ b/lib/generators/samvera/nesting_indexer/install_generator.rb
@@ -8,7 +8,7 @@ module Samvera
       # Responsible for exposing the install generator (e.g. rails generator install amvera:nesting_indexer:install)
       class InstallGenerator < Rails::Generators::Base
         DEFAULT_MAXIMUM_NESTING_DEPTH = 5
-        source_root File.expand_path("../templates", __FILE__)
+        source_root File.expand_path('templates', __dir__)
         desc "Creates a Samvera::NestingIndexer initializer."
         class_option(
           :adapter,

--- a/lib/samvera/nesting_indexer.rb
+++ b/lib/samvera/nesting_indexer.rb
@@ -18,12 +18,13 @@ module Samvera
     # @param id [String] - The permanent identifier of the object that will be reindexed along with its children.
     # @param maximum_nesting_depth [Integer] - used to short-circuit overly deep nesting as well as prevent accidental cyclic graphs
     #                                          from creating an infinite loop.
+    # @param extent [String] - any value other than "full or nil is used to force adapter skip all children which already contain the indexing fields
     # @return [Boolean] - It was successful
     # @raise Samvera::Exceptions::CycleDetectionError - A possible cycle was detected
     # @raise Samvera::Exceptions::ExceededMaximumNestingDepthError - We exceeded our maximum depth
     # @raise Samvera::Exceptions::DocumentIsItsOwnAncestorError - A document we were about to index appeared to be its own ancestor
-    def self.reindex_relationships(id:, maximum_nesting_depth: configuration.maximum_nesting_depth)
-      RelationshipReindexer.call(id: id, maximum_nesting_depth: maximum_nesting_depth, configuration: configuration)
+    def self.reindex_relationships(id:, maximum_nesting_depth: configuration.maximum_nesting_depth, extent: nil)
+      RelationshipReindexer.call(id: id, maximum_nesting_depth: maximum_nesting_depth, configuration: configuration, extent: extent)
       true
     end
 

--- a/lib/samvera/nesting_indexer/adapters/abstract_adapter.rb
+++ b/lib/samvera/nesting_indexer/adapters/abstract_adapter.rb
@@ -37,8 +37,9 @@ module Samvera
 
         # @api public
         # @param document [Samvera::NestingIndexer::Documents::IndexDocument]
+        # @param extent [String] passed into adapter from reindex_relationships call
         # @yield [Samvera::NestingIndexer::Documents::IndexDocument]
-        def self.each_child_document_of(document:, &block)
+        def self.each_child_document_of(document:, extent:, &block)
           raise NotImplementedError
         end
 

--- a/lib/samvera/nesting_indexer/adapters/in_memory_adapter.rb
+++ b/lib/samvera/nesting_indexer/adapters/in_memory_adapter.rb
@@ -43,11 +43,14 @@ module Samvera
 
         # @api public
         # @param document [Samvera::NestingIndexer::Documents::IndexDocument]
+        # @param extent [String] passed into adapter from reindex_relationships call
         # @yield [Samvera::NestingIndexer::Documents::IndexDocument]
-        def self.each_child_document_of(document:, &block)
+        # rubocop:disable Lint/UnusedMethodArgument
+        def self.each_child_document_of(document:, extent:, &block)
           SemverAssistant.removing_from_public_api(context: "#{self.class}##{__method__}", as_of: '2.0.0')
-          Index.each_child_document_of(document: document, &block)
+          Index.each_child_document_of(document: document, extent: nil, &block)
         end
+        # rubocop:enable Lint/UnusedMethodArgument
 
         # @api public
         # This is not something that I envision using in the production environment;
@@ -172,9 +175,11 @@ module Samvera
             Storage.find_each(&block)
           end
 
-          def self.each_child_document_of(document:, &block)
+          # rubocop:disable Lint/UnusedMethodArgument
+          def self.each_child_document_of(document:, extent: nil, &block)
             Storage.find_children_of_id(document.id).each(&block)
           end
+          # rubocop:enable Lint/UnusedMethodArgument
 
           def self.write_to_storage(doc)
             Storage.write(doc)

--- a/lib/samvera/nesting_indexer/adapters/interface_behavior_spec.rb
+++ b/lib/samvera/nesting_indexer/adapters/interface_behavior_spec.rb
@@ -68,10 +68,10 @@ if defined?(RSpec)
       subject { described_class.method(:each_child_document_of) }
 
       it 'requires the :document keyword (and does not require any others)' do
-        expect(required_keyword_parameters.call(subject)).to eq([:document])
+        expect(required_keyword_parameters.call(subject)).to eq(%i(document extent))
       end
 
-      it 'does not require any other parameters (besides :document)' do
+      it 'does not require any other parameters (besides :document, :extent)' do
         expect(required_parameters.call(subject)).to eq(required_keyword_parameters.call(subject))
       end
 

--- a/spec/features/reindex_pid_and_descendants_spec.rb
+++ b/spec/features/reindex_pid_and_descendants_spec.rb
@@ -111,7 +111,7 @@ module Samvera
               write_document_to_persistence_layers(preservation_document_attributes_to_update)
 
               # Run the "job" that will reindex the relationships for the given id.
-              NestingIndexer.reindex_relationships(id: preservation_document_attributes_to_update.fetch(:id))
+              NestingIndexer.reindex_relationships(id: preservation_document_attributes_to_update.fetch(:id), extent: nil)
 
               # A custom spec helper that verifies the expected ending graph versus the actual graph as retrieved
               # This verifies the "ending" data state
@@ -130,10 +130,11 @@ module Samvera
           }
           build_graph(starting_graph)
 
-          expect { NestingIndexer.reindex_relationships(id: :a) }.to raise_error(Exceptions::CycleDetectionError)
+          expect { NestingIndexer.reindex_relationships(id: :a, extent: nil) }.to raise_error(Exceptions::CycleDetectionError)
         end
 
         it 'catches a simple cyclic graph (start with A ={ B and add B ={ A relationship)' do
+          ancestor_error = Samvera::NestingIndexer::Exceptions::DocumentIsItsOwnAncestorError
           starting_graph = {
             parent_ids: { a: [], b: ['a'] }
           }
@@ -150,13 +151,14 @@ module Samvera
 
           # We are writing (and succeeding at writing) a cyclic relationship
           NestingIndexer.adapter.write_document_attributes_to_preservation_layer(id: :a, parent_ids: ['b'])
-          expect { NestingIndexer.reindex_relationships(id: :a) }.to raise_error(Samvera::NestingIndexer::Exceptions::DocumentIsItsOwnAncestorError)
+          expect { NestingIndexer.reindex_relationships(id: :a, extent: nil) }.to raise_error(ancestor_error)
 
           # We should have the same index that we started with.
           verify_graph_versus_storage(ending_graph)
         end
 
         it 'catches a simple cyclic graph (start with A ={ B ={ C and add C ={ B relationship)' do
+          ancestor_error = Samvera::NestingIndexer::Exceptions::DocumentIsItsOwnAncestorError
           starting_graph = {
             parent_ids: { a: [], b: ['a'], c: ['b'] }
           }
@@ -173,7 +175,7 @@ module Samvera
 
           # We are writing (and succeeding at writing) a cyclic relationship
           NestingIndexer.adapter.write_document_attributes_to_preservation_layer(id: :b, parent_ids: ['a', 'c'])
-          expect { NestingIndexer.reindex_relationships(id: :b) }.to raise_error(Samvera::NestingIndexer::Exceptions::DocumentIsItsOwnAncestorError)
+          expect { NestingIndexer.reindex_relationships(id: :b, extent: nil) }.to raise_error(ancestor_error)
 
           # We should have the same index that we started with.
           verify_graph_versus_storage(ending_graph)
@@ -185,10 +187,10 @@ module Samvera
           }
           build_graph(starting_graph)
           # If we give enough time to live this will index
-          expect { NestingIndexer.reindex_relationships(id: :a, maximum_nesting_depth: 5) }.not_to raise_error
+          expect { NestingIndexer.reindex_relationships(id: :a, maximum_nesting_depth: 5, extent: nil) }.not_to raise_error
 
           # If we don't give enough time to live this will fail in indexing
-          expect { NestingIndexer.reindex_relationships(id: :a, maximum_nesting_depth: 2) }.to(
+          expect { NestingIndexer.reindex_relationships(id: :a, maximum_nesting_depth: 2, extent: nil) }.to(
             raise_error(Samvera::NestingIndexer::Exceptions::CycleDetectionError)
           )
         end

--- a/spec/lib/samvera/nesting_indexer/adapters/abstract_adapter_spec.rb
+++ b/spec/lib/samvera/nesting_indexer/adapters/abstract_adapter_spec.rb
@@ -36,7 +36,7 @@ module Samvera
         end
 
         describe '.each_child_document_of' do
-          subject { described_class.each_child_document_of(document: double) }
+          subject { described_class.each_child_document_of(document: double, extent: nil) }
           it 'is defined but requires implementation in classes that extend this class (see documentation)' do
             expect { subject }.to raise_error(NotImplementedError)
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 SUPPRESS_MEMORY_ADAPTER_WARNING = true
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'coverage_helper'
 require 'samvera/nesting_indexer'
 require 'rspec/its'


### PR DESCRIPTION
### Memoize Initial Index Document variable
Save value of `initial_index_document` to avoid multiple calls to adapter to load the same information.
### Add :extent parameter
Add optional `:extent` parameter to `reindex_relationships` method, and pass it through the adapter call to `each_child_document_of`. When used, the adapter receives the value and can vary behavior based it. 

The intent of this method is to allow adapter to determine which children to return for reindexing rather than to always reindex the full graph. When no changes are being made to the nesting, it is technically not necessary to reindex the full graph... only the object being saved would need reindexing to add the nesting fields back onto it. As long as the children contain these fields, they do not need reindexing unless the object being indexed is the one being nested.

@samvera/hyrax-code-reviewers
