### PR TITLE
Skip Failures Option

### DIFF
--- a/lib/samvera/nesting_indexer/configuration.rb
+++ b/lib/samvera/nesting_indexer/configuration.rb
@@ -12,11 +12,12 @@ module Samvera
       def initialize(maximum_nesting_depth: DEFAULT_MAXIMUM_NESTING_DEPTH, logger: default_logger)
         self.maximum_nesting_depth = maximum_nesting_depth
         self.logger = logger
+        self.stop_on_failure = true
       end
 
-      attr_reader :maximum_nesting_depth, :logger
+      attr_reader :maximum_nesting_depth, :logger, :stop_on_failure
 
-      attr_writer :logger
+      attr_writer :logger, :stop_on_failure
 
       def maximum_nesting_depth=(input)
         @maximum_nesting_depth = input.to_i

--- a/lib/samvera/nesting_indexer/repository_reindexer.rb
+++ b/lib/samvera/nesting_indexer/repository_reindexer.rb
@@ -44,6 +44,7 @@ module Samvera
       extend Forwardable
       def_delegator :configuration, :adapter
       def_delegator :configuration, :logger
+      def_delegator :configuration, :stop_on_failure
 
       # When we find a document, reindex it if it doesn't have a parent. If it has a parent, reindex the parent first.
       #
@@ -66,8 +67,9 @@ module Samvera
         id_reindexer.call(id: id, extent: extent)
         processed_ids << id
       rescue StandardError => e
+        logger.error("Failed: #{id}")
         logger.error(e)
-        raise Exceptions::ReindexingError.new(id, e)
+        raise Exceptions::ReindexingError.new(id, e) if stop_on_failure
       end
     end
   end


### PR DESCRIPTION
Add configuration option to continue on failures so that a single bad uri does not stop a complete reindex

@samvera/hyrax-code-reviewers
